### PR TITLE
Add go 1.7 compatibility

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -355,6 +355,92 @@ var testCases = []TestCase{
 			},
 		},
 	},
+	{
+		name:       "12-go_1_7.txt",
+		reportName: "12-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name: "package/name",
+					Time: 50,
+					Tests: []*parser.Test{
+						{
+							Name:   "TestOne",
+							Time:   10,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestOne/Child",
+							Time:   20,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestOne/Child#01",
+							Time:   30,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestOne/Child=02",
+							Time:   40,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestTwo",
+							Time:   10,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestTwo/Child",
+							Time:   20,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestTwo/Child#01",
+							Time:   30,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestTwo/Child=02",
+							Time:   40,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestThree",
+							Time:   10,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestThree/a#1",
+							Time:   20,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestThree/a#1/b#1",
+							Time:   30,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestThree/a#1/b#1/c#1",
+							Time:   40,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestParser(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -40,7 +40,7 @@ type Test struct {
 }
 
 var (
-	regexStatus   = regexp.MustCompile(`^--- (PASS|FAIL|SKIP): (.+) \((\d+\.\d+)(?: seconds|s)\)$`)
+	regexStatus   = regexp.MustCompile(`^\s*--- (PASS|FAIL|SKIP): (.+) \((\d+\.\d+)(?: seconds|s)\)$`)
 	regexCoverage = regexp.MustCompile(`^coverage:\s+(\d+\.\d+)%\s+of\s+statements$`)
 	regexResult   = regexp.MustCompile(`^(ok|FAIL)\s+(.+)\s(\d+\.\d+)s(?:\s+coverage:\s+(\d+\.\d+)%\s+of\s+statements)?$`)
 )

--- a/tests/12-go_1_7.txt
+++ b/tests/12-go_1_7.txt
@@ -1,0 +1,26 @@
+=== RUN   TestOne
+=== RUN   TestOne/Child
+=== RUN   TestOne/Child#01
+=== RUN   TestOne/Child=02
+--- PASS: TestOne (0.01s)
+    --- PASS: TestOne/Child (0.02s)
+    --- PASS: TestOne/Child#01 (0.03s)
+    --- PASS: TestOne/Child=02 (0.04s)
+=== RUN   TestTwo
+=== RUN   TestTwo/Child
+=== RUN   TestTwo/Child#01
+=== RUN   TestTwo/Child=02
+--- PASS: TestTwo (0.01s)
+    --- PASS: TestTwo/Child (0.02s)
+    --- PASS: TestTwo/Child#01 (0.03s)
+    --- PASS: TestTwo/Child=02 (0.04s)
+=== RUN   TestThree
+=== RUN   TestThree/a#1
+=== RUN   TestThree/a#1/b#1
+=== RUN   TestThree/a#1/b#1/c#1
+--- PASS: TestThree (0.01s)
+    --- PASS: TestThree/a#1 (0.02s)
+        --- PASS: TestThree/a#1/b#1 (0.03s)
+            --- PASS: TestThree/a#1/b#1/c#1 (0.04s)
+PASS
+ok  	package/name	0.050s

--- a/tests/12-report.xml
+++ b/tests/12-report.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="12" failures="0" time="0.050" name="package/name">
+		<properties>
+			<property name="go.version" value="go1.7"></property>
+		</properties>
+		<testcase classname="name" name="TestOne" time="0.010"></testcase>
+		<testcase classname="name" name="TestOne/Child" time="0.020"></testcase>
+		<testcase classname="name" name="TestOne/Child#01" time="0.030"></testcase>
+		<testcase classname="name" name="TestOne/Child=02" time="0.040"></testcase>
+		<testcase classname="name" name="TestTwo" time="0.010"></testcase>
+		<testcase classname="name" name="TestTwo/Child" time="0.020"></testcase>
+		<testcase classname="name" name="TestTwo/Child#01" time="0.030"></testcase>
+		<testcase classname="name" name="TestTwo/Child=02" time="0.040"></testcase>
+		<testcase classname="name" name="TestThree" time="0.010"></testcase>
+		<testcase classname="name" name="TestThree/a#1" time="0.020"></testcase>
+		<testcase classname="name" name="TestThree/a#1/b#1" time="0.030"></testcase>
+		<testcase classname="name" name="TestThree/a#1/b#1/c#1" time="0.040"></testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
- Subtests and nested subtests have spaces at the beginning of their
  PASS statements. This has been added to the regexp.
